### PR TITLE
Use array rather than object for ACL arguments

### DIFF
--- a/pkg/service/loadbalancer/model.go
+++ b/pkg/service/loadbalancer/model.go
@@ -239,15 +239,15 @@ type ACLArgument struct {
 
 // ACLCondition represents an ACL condition
 type ACLCondition struct {
-	Name      string                 `json:"name"`
-	Inverted  bool                   `json:"inverted"`
-	Arguments map[string]ACLArgument `json:"arguments"`
+	Name      string        `json:"name"`
+	Inverted  bool          `json:"inverted"`
+	Arguments []ACLArgument `json:"arguments"`
 }
 
 // ACLAction represents an ACL action
 type ACLAction struct {
-	Name      string                 `json:"name"`
-	Arguments map[string]ACLArgument `json:"arguments"`
+	Name      string        `json:"name"`
+	Arguments []ACLArgument `json:"arguments"`
 }
 
 // ACLTemplates represents a collection of ACL condition/action templates


### PR DESCRIPTION
Whilst the API accepts a dictionary, the expected format is an array. Lets update this to ensure future changes do not break this implementation