### PR TITLE
Add support for instance sockets/cores options

### DIFF
--- a/pkg/service/ecloud/model.go
+++ b/pkg/service/ecloud/model.go
@@ -426,6 +426,8 @@ type Instance struct {
 	AvailabilityZoneID string              `json:"availability_zone_id"`
 	ImageID            string              `json:"image_id"`
 	VCPUCores          int                 `json:"vcpu_cores"`
+	VCPUSockets        int                 `json:"vcpu_sockets"`
+	VCPUCoresPerSocket int                 `json:"vcpu_cores_per_socket"`
 	RAMCapacity        int                 `json:"ram_capacity"`
 	Locked             bool                `json:"locked"`
 	BackupEnabled      bool                `json:"backup_enabled"`

--- a/pkg/service/ecloud/request.go
+++ b/pkg/service/ecloud/request.go
@@ -239,7 +239,9 @@ type CreateInstanceRequest struct {
 	VPCID              string                 `json:"vpc_id"`
 	ImageID            string                 `json:"image_id"`
 	ImageData          map[string]interface{} `json:"image_data"`
-	VCPUCores          int                    `json:"vcpu_cores"`
+	VCPUCores          int                    `json:"vcpu_cores,omitempty"`
+	VCPUSockets        int                    `json:"vcpu_sockets,omitempty"`
+	VCPUCoresPerSocket int                    `json:"vcpu_cores_per_socket,omitempty"`
 	RAMCapacity        int                    `json:"ram_capacity"`
 	Locked             bool                   `json:"locked"`
 	VolumeCapacity     int                    `json:"volume_capacity"`
@@ -258,10 +260,12 @@ type CreateInstanceRequest struct {
 
 // PatchInstanceRequest represents a request to patch an instance
 type PatchInstanceRequest struct {
-	Name          string  `json:"name,omitempty"`
-	VCPUCores     int     `json:"vcpu_cores,omitempty"`
-	RAMCapacity   int     `json:"ram_capacity,omitempty"`
-	VolumeGroupID *string `json:"volume_group_id,omitempty"`
+	Name               string  `json:"name,omitempty"`
+	VCPUCores          int     `json:"vcpu_cores,omitempty"`
+	VCPUSockets        int     `json:"vcpu_sockets,omitempty"`
+	VCPUCoresPerSocket int     `json:"vcpu_cores_per_socket,omitempty"`
+	RAMCapacity        int     `json:"ram_capacity,omitempty"`
+	VolumeGroupID      *string `json:"volume_group_id,omitempty"`
 }
 
 // CreateFirewallPolicyRequest represents a request to create a firewall policy


### PR DESCRIPTION
Adds support for the new `vcpu_sockets`, `vcpu_cores_per_socket` options along with validation to prevent these being provided with the `vcpu_cores` option.