### PR TITLE
Add support for the new tags endpoint

### DIFF
--- a/pkg/service/ecloud/error.go
+++ b/pkg/service/ecloud/error.go
@@ -11,12 +11,12 @@ func (e *VirtualMachineNotFoundError) Error() string {
 	return fmt.Sprintf("virtual machine not found with ID [%d]", e.ID)
 }
 
-// TagNotFoundError indicates a tag was not found within eCloud
-type TagNotFoundError struct {
+// TagV1NotFoundError indicates a v1 tag was not found within eCloud
+type TagV1NotFoundError struct {
 	Key string
 }
 
-func (e *TagNotFoundError) Error() string {
+func (e *TagV1NotFoundError) Error() string {
 	return fmt.Sprintf("tag not found with key [%s]", e.Key)
 }
 
@@ -524,11 +524,11 @@ func (e *MonitoringGatewayNotFoundError) Error() string {
 	return fmt.Sprintf("Monitoring gateway not found with ID [%s]", e.ID)
 }
 
-// TagV2NotFoundError represents a v2 tag not found error
-type TagV2NotFoundError struct {
+// TagNotFoundError represents a tag not found error
+type TagNotFoundError struct {
 	ID string
 }
 
-func (e *TagV2NotFoundError) Error() string {
+func (e *TagNotFoundError) Error() string {
 	return fmt.Sprintf("ecloud: tag not found with ID [%s]", e.ID)
 }

--- a/pkg/service/ecloud/error.go
+++ b/pkg/service/ecloud/error.go
@@ -523,3 +523,12 @@ type MonitoringGatewayNotFoundError struct {
 func (e *MonitoringGatewayNotFoundError) Error() string {
 	return fmt.Sprintf("Monitoring gateway not found with ID [%s]", e.ID)
 }
+
+// TagV2NotFoundError represents a v2 tag not found error
+type TagV2NotFoundError struct {
+	ID string
+}
+
+func (e *TagV2NotFoundError) Error() string {
+	return fmt.Sprintf("ecloud: tag not found with ID [%s]", e.ID)
+}

--- a/pkg/service/ecloud/model.go
+++ b/pkg/service/ecloud/model.go
@@ -1099,3 +1099,13 @@ type MonitoringGateway struct {
 	CreatedAt          connection.DateTime `json:"created_at"`
 	UpdatedAt          connection.DateTime `json:"updated_at"`
 }
+
+// TagV2 represents an eCloud v2 tag
+type TagV2 struct {
+	ID         string              `json:"id"`
+	ResellerID int                 `json:"reseller_id"`
+	Name       string              `json:"name"`
+	Scope      string              `json:"scope"`
+	CreatedAt  connection.DateTime `json:"created_at"`
+	UpdatedAt  connection.DateTime `json:"updated_at"`
+}

--- a/pkg/service/ecloud/model.go
+++ b/pkg/service/ecloud/model.go
@@ -1100,7 +1100,7 @@ type MonitoringGateway struct {
 	UpdatedAt          connection.DateTime `json:"updated_at"`
 }
 
-// Tag represents an eCloud tag
+// Tag represents an eCloud VPC tag
 type Tag struct {
 	ID         string              `json:"id"`
 	ResellerID int                 `json:"reseller_id"`

--- a/pkg/service/ecloud/model.go
+++ b/pkg/service/ecloud/model.go
@@ -99,8 +99,8 @@ type VirtualMachineDisk struct {
 	Capacity int `json:"capacity"`
 }
 
-// Tag represents an eCloud tag
-type Tag struct {
+// TagV1 represents an eCloud v1 tag
+type TagV1 struct {
 	Key       string              `json:"key"`
 	Value     string              `json:"value"`
 	CreatedAt connection.DateTime `json:"created_at"`
@@ -1100,8 +1100,8 @@ type MonitoringGateway struct {
 	UpdatedAt          connection.DateTime `json:"updated_at"`
 }
 
-// TagV2 represents an eCloud v2 tag
-type TagV2 struct {
+// Tag represents an eCloud tag
+type Tag struct {
 	ID         string              `json:"id"`
 	ResellerID int                 `json:"reseller_id"`
 	Name       string              `json:"name"`

--- a/pkg/service/ecloud/request.go
+++ b/pkg/service/ecloud/request.go
@@ -697,3 +697,27 @@ type CreateNICRequest struct {
 type PatchNICRequest struct {
 	Name string `json:"name"`
 }
+
+// CreateTagV2Request represents a request to create an eCloud v2 tag
+type CreateTagV2Request struct {
+	connection.APIRequestBodyDefaultValidator
+
+	Name  string `json:"name" validate:"required"`
+	Scope string `json:"scope,omitempty"`
+}
+
+// Validate returns an error if struct properties are missing/invalid
+func (c *CreateTagV2Request) Validate() *connection.ValidationError {
+	return c.APIRequestBodyDefaultValidator.Validate(c)
+}
+
+// PatchTagV2Request represents a request to patch an eCloud v2 tag
+type PatchTagV2Request struct {
+	Name  string `json:"name,omitempty"`
+	Scope string `json:"scope,omitempty"`
+}
+
+// Validate returns an error if struct properties are missing/invalid
+func (c *PatchTagV2Request) Validate() *connection.ValidationError {
+	return nil
+}

--- a/pkg/service/ecloud/request.go
+++ b/pkg/service/ecloud/request.go
@@ -4,18 +4,18 @@ import (
 	"github.com/ans-group/sdk-go/pkg/connection"
 )
 
-// PatchTagRequest represents an eCloud tag patch request
-type PatchTagRequest struct {
+// PatchTagV1Request represents an eCloud v1 tag patch request
+type PatchTagV1Request struct {
 	Value string `json:"value,omitempty"`
 }
 
 // Validate returns an error if struct properties are missing/invalid
-func (c *PatchTagRequest) Validate() *connection.ValidationError {
+func (c *PatchTagV1Request) Validate() *connection.ValidationError {
 	return nil
 }
 
-// CreateTagRequest represents a request to create an eCloud tag
-type CreateTagRequest struct {
+// CreateTagV1Request represents a request to create an eCloud v1 tag
+type CreateTagV1Request struct {
 	connection.APIRequestBodyDefaultValidator
 
 	Key   string `json:"key" validate:"required"`
@@ -23,7 +23,7 @@ type CreateTagRequest struct {
 }
 
 // Validate returns an error if struct properties are missing/invalid
-func (c *CreateTagRequest) Validate() *connection.ValidationError {
+func (c *CreateTagV1Request) Validate() *connection.ValidationError {
 	return c.APIRequestBodyDefaultValidator.Validate(c)
 }
 
@@ -44,7 +44,7 @@ type CreateVirtualMachineRequest struct {
 	Disks                   []CreateVirtualMachineRequestDisk      `json:"hdd_disks,omitempty"`
 	Name                    string                                 `json:"name,omitempty"`
 	ComputerName            string                                 `json:"computername,omitempty"`
-	Tags                    []CreateTagRequest                     `json:"tags,omitempty"`
+	Tags                    []CreateTagV1Request                   `json:"tags,omitempty"`
 	Backup                  bool                                   `json:"backup"`
 	Support                 bool                                   `json:"support"`
 	Monitoring              bool                                   `json:"monitoring"`
@@ -698,8 +698,8 @@ type PatchNICRequest struct {
 	Name string `json:"name"`
 }
 
-// CreateTagV2Request represents a request to create an eCloud v2 tag
-type CreateTagV2Request struct {
+// CreateTagRequest represents a request to create an eCloud tag
+type CreateTagRequest struct {
 	connection.APIRequestBodyDefaultValidator
 
 	Name  string `json:"name" validate:"required"`
@@ -707,17 +707,17 @@ type CreateTagV2Request struct {
 }
 
 // Validate returns an error if struct properties are missing/invalid
-func (c *CreateTagV2Request) Validate() *connection.ValidationError {
+func (c *CreateTagRequest) Validate() *connection.ValidationError {
 	return c.APIRequestBodyDefaultValidator.Validate(c)
 }
 
-// PatchTagV2Request represents a request to patch an eCloud v2 tag
-type PatchTagV2Request struct {
+// PatchTagRequest represents a request to patch an eCloud tag
+type PatchTagRequest struct {
 	Name  string `json:"name,omitempty"`
 	Scope string `json:"scope,omitempty"`
 }
 
 // Validate returns an error if struct properties are missing/invalid
-func (c *PatchTagV2Request) Validate() *connection.ValidationError {
+func (c *PatchTagRequest) Validate() *connection.ValidationError {
 	return nil
 }

--- a/pkg/service/ecloud/request_test.go
+++ b/pkg/service/ecloud/request_test.go
@@ -6,17 +6,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPatchTagRequest_Validate_NoError(t *testing.T) {
-	r := PatchTagRequest{}
+func TestPatchTagV1Request_Validate_NoError(t *testing.T) {
+	r := PatchTagV1Request{}
 
 	err := r.Validate()
 
 	assert.Nil(t, err)
 }
 
-func TestCreateTagRequest_Validate(t *testing.T) {
+func TestCreateTagV1Request_Validate(t *testing.T) {
 	t.Run("Valid_NoError", func(t *testing.T) {
-		c := CreateTagRequest{
+		c := CreateTagV1Request{
 			Key:   "testkey1",
 			Value: "testvalue1",
 		}
@@ -27,7 +27,7 @@ func TestCreateTagRequest_Validate(t *testing.T) {
 	})
 
 	t.Run("Invalid_Error", func(t *testing.T) {
-		c := CreateTagRequest{}
+		c := CreateTagV1Request{}
 
 		err := c.Validate()
 

--- a/pkg/service/ecloud/service.go
+++ b/pkg/service/ecloud/service.go
@@ -21,12 +21,12 @@ type ECloudService interface {
 	PowerShutdownVirtualMachine(vmID int) error
 	PowerRestartVirtualMachine(vmID int) error
 	CreateVirtualMachineTemplate(vmID int, req CreateVirtualMachineTemplateRequest) error
-	GetVirtualMachineTags(vmID int, parameters connection.APIRequestParameters) ([]Tag, error)
-	GetVirtualMachineTagsPaginated(vmID int, parameters connection.APIRequestParameters) (*connection.Paginated[Tag], error)
-	GetVirtualMachineTag(vmID int, tagKey string) (Tag, error)
-	CreateVirtualMachineTag(vmID int, req CreateTagRequest) error
-	PatchVirtualMachineTag(vmID int, tagKey string, patch PatchTagRequest) error
-	DeleteVirtualMachineTag(vmID int, tagKey string) error
+	GetVirtualMachineTagsV1(vmID int, parameters connection.APIRequestParameters) ([]TagV1, error)
+	GetVirtualMachineTagsV1Paginated(vmID int, parameters connection.APIRequestParameters) (*connection.Paginated[TagV1], error)
+	GetVirtualMachineTagV1(vmID int, tagKey string) (TagV1, error)
+	CreateVirtualMachineTagV1(vmID int, req CreateTagV1Request) error
+	PatchVirtualMachineTagV1(vmID int, tagKey string, patch PatchTagV1Request) error
+	DeleteVirtualMachineTagV1(vmID int, tagKey string) error
 	CreateVirtualMachineConsoleSession(vmID int) (ConsoleSession, error)
 
 	// Solution
@@ -51,12 +51,12 @@ type ECloudService interface {
 	GetSolutionTemplate(solutionID int, templateName string) (Template, error)
 	DeleteSolutionTemplate(solutionID int, templateName string) error
 	RenameSolutionTemplate(solutionID int, templateName string, req RenameTemplateRequest) error
-	GetSolutionTags(solutionID int, parameters connection.APIRequestParameters) ([]Tag, error)
-	GetSolutionTagsPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[Tag], error)
-	GetSolutionTag(solutionID int, tagKey string) (Tag, error)
-	CreateSolutionTag(solutionID int, req CreateTagRequest) error
-	PatchSolutionTag(solutionID int, tagKey string, patch PatchTagRequest) error
-	DeleteSolutionTag(solutionID int, tagKey string) error
+	GetSolutionTagsV1(solutionID int, parameters connection.APIRequestParameters) ([]TagV1, error)
+	GetSolutionTagsV1Paginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[TagV1], error)
+	GetSolutionTagV1(solutionID int, tagKey string) (TagV1, error)
+	CreateSolutionTagV1(solutionID int, req CreateTagV1Request) error
+	PatchSolutionTagV1(solutionID int, tagKey string, patch PatchTagV1Request) error
+	DeleteSolutionTagV1(solutionID int, tagKey string) error
 
 	// Site
 	GetSites(parameters connection.APIRequestParameters) ([]Site, error)
@@ -510,13 +510,13 @@ type ECloudService interface {
 	PatchMonitoringGateway(gatewayID string, req PatchMonitoringGatewayRequest) (TaskReference, error)
 	DeleteMonitoringGateway(gatewayID string) (string, error)
 
-	// Tags V2
-	GetTagsV2(parameters connection.APIRequestParameters) ([]TagV2, error)
-	GetTagsV2Paginated(parameters connection.APIRequestParameters) (*connection.Paginated[TagV2], error)
-	GetTagV2(tagID string) (TagV2, error)
-	CreateTagV2(req CreateTagV2Request) (string, error)
-	PatchTagV2(tagID string, req PatchTagV2Request) error
-	DeleteTagV2(tagID string) error
+	// Tags
+	GetTags(parameters connection.APIRequestParameters) ([]Tag, error)
+	GetTagsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Tag], error)
+	GetTag(tagID string) (Tag, error)
+	CreateTag(req CreateTagRequest) (string, error)
+	PatchTag(tagID string, req PatchTagRequest) error
+	DeleteTag(tagID string) error
 }
 
 // Service implements ECloudService for managing

--- a/pkg/service/ecloud/service.go
+++ b/pkg/service/ecloud/service.go
@@ -509,6 +509,14 @@ type ECloudService interface {
 	CreateMonitoringGateway(req CreateMonitoringGatewayRequest) (TaskReference, error)
 	PatchMonitoringGateway(gatewayID string, req PatchMonitoringGatewayRequest) (TaskReference, error)
 	DeleteMonitoringGateway(gatewayID string) (string, error)
+
+	// Tags V2
+	GetTagsV2(parameters connection.APIRequestParameters) ([]TagV2, error)
+	GetTagsV2Paginated(parameters connection.APIRequestParameters) (*connection.Paginated[TagV2], error)
+	GetTagV2(tagID string) (TagV2, error)
+	CreateTagV2(req CreateTagV2Request) (string, error)
+	PatchTagV2(tagID string, req PatchTagV2Request) error
+	DeleteTagV2(tagID string) error
 }
 
 // Service implements ECloudService for managing

--- a/pkg/service/ecloud/service_solution.go
+++ b/pkg/service/ecloud/service_solution.go
@@ -437,23 +437,23 @@ func (s *Service) deleteSolutionTemplateResponseBody(solutionID int, templateNam
 }
 
 // GetSolutionTags retrieves a list of tags
-func (s *Service) GetSolutionTags(solutionID int, parameters connection.APIRequestParameters) ([]Tag, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Tag], error) {
-		return s.GetSolutionTagsPaginated(solutionID, p)
+func (s *Service) GetSolutionTagsV1(solutionID int, parameters connection.APIRequestParameters) ([]TagV1, error) {
+	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[TagV1], error) {
+		return s.GetSolutionTagsV1Paginated(solutionID, p)
 	}, parameters)
 }
 
-// GetSolutionTagsPaginated retrieves a paginated list of domains
-func (s *Service) GetSolutionTagsPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[Tag], error) {
-	body, err := s.getSolutionTagsPaginatedResponseBody(solutionID, parameters)
+// GetSolutionTagsV1Paginated retrieves a paginated list of v1 solution tags
+func (s *Service) GetSolutionTagsV1Paginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[TagV1], error) {
+	body, err := s.getSolutionTagsV1PaginatedResponseBody(solutionID, parameters)
 
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Tag], error) {
-		return s.GetSolutionTagsPaginated(solutionID, p)
+	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[TagV1], error) {
+		return s.GetSolutionTagsV1Paginated(solutionID, p)
 	}), err
 }
 
-func (s *Service) getSolutionTagsPaginatedResponseBody(solutionID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Tag], error) {
-	body := &connection.APIResponseBodyData[[]Tag]{}
+func (s *Service) getSolutionTagsV1PaginatedResponseBody(solutionID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]TagV1], error) {
+	body := &connection.APIResponseBodyData[[]TagV1]{}
 
 	if solutionID < 1 {
 		return body, fmt.Errorf("invalid solution id")
@@ -473,15 +473,15 @@ func (s *Service) getSolutionTagsPaginatedResponseBody(solutionID int, parameter
 	})
 }
 
-// GetSolutionTag retrieves a single solution tag by key
-func (s *Service) GetSolutionTag(solutionID int, tagKey string) (Tag, error) {
-	body, err := s.getSolutionTagResponseBody(solutionID, tagKey)
+// GetSolutionTagV1 retrieves a single solution v1 tag by key
+func (s *Service) GetSolutionTagV1(solutionID int, tagKey string) (TagV1, error) {
+	body, err := s.getSolutionTagV1ResponseBody(solutionID, tagKey)
 
 	return body.Data, err
 }
 
-func (s *Service) getSolutionTagResponseBody(solutionID int, tagKey string) (*connection.APIResponseBodyData[Tag], error) {
-	body := &connection.APIResponseBodyData[Tag]{}
+func (s *Service) getSolutionTagV1ResponseBody(solutionID int, tagKey string) (*connection.APIResponseBodyData[TagV1], error) {
+	body := &connection.APIResponseBodyData[TagV1]{}
 
 	if solutionID < 1 {
 		return body, fmt.Errorf("invalid solution id")
@@ -497,21 +497,21 @@ func (s *Service) getSolutionTagResponseBody(solutionID int, tagKey string) (*co
 
 	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
 		if response.StatusCode == 404 {
-			return &TagNotFoundError{Key: tagKey}
+			return &TagV1NotFoundError{Key: tagKey}
 		}
 
 		return nil
 	})
 }
 
-// CreateSolutionTag creates a new solution tag
-func (s *Service) CreateSolutionTag(solutionID int, req CreateTagRequest) error {
-	_, err := s.createSolutionTagResponseBody(solutionID, req)
+// CreateSolutionTagV1 creates a new solution v1 tag
+func (s *Service) CreateSolutionTagV1(solutionID int, req CreateTagV1Request) error {
+	_, err := s.createSolutionTagV1ResponseBody(solutionID, req)
 
 	return err
 }
 
-func (s *Service) createSolutionTagResponseBody(solutionID int, req CreateTagRequest) (*connection.APIResponseBody, error) {
+func (s *Service) createSolutionTagV1ResponseBody(solutionID int, req CreateTagV1Request) (*connection.APIResponseBody, error) {
 	body := &connection.APIResponseBody{}
 
 	if solutionID < 1 {
@@ -532,14 +532,14 @@ func (s *Service) createSolutionTagResponseBody(solutionID int, req CreateTagReq
 	})
 }
 
-// PatchSolutionTag patches an eCloud solution tag
-func (s *Service) PatchSolutionTag(solutionID int, tagKey string, patch PatchTagRequest) error {
-	_, err := s.patchSolutionTagResponseBody(solutionID, tagKey, patch)
+// PatchSolutionTagV1 patches an eCloud solution v1 tag
+func (s *Service) PatchSolutionTagV1(solutionID int, tagKey string, patch PatchTagV1Request) error {
+	_, err := s.patchSolutionTagV1ResponseBody(solutionID, tagKey, patch)
 
 	return err
 }
 
-func (s *Service) patchSolutionTagResponseBody(solutionID int, tagKey string, patch PatchTagRequest) (*connection.APIResponseBody, error) {
+func (s *Service) patchSolutionTagV1ResponseBody(solutionID int, tagKey string, patch PatchTagV1Request) (*connection.APIResponseBody, error) {
 	body := &connection.APIResponseBody{}
 
 	if solutionID < 1 {
@@ -556,21 +556,21 @@ func (s *Service) patchSolutionTagResponseBody(solutionID int, tagKey string, pa
 
 	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
 		if response.StatusCode == 404 {
-			return &TagNotFoundError{Key: tagKey}
+			return &TagV1NotFoundError{Key: tagKey}
 		}
 
 		return nil
 	})
 }
 
-// DeleteSolutionTag removes a solution tag
-func (s *Service) DeleteSolutionTag(solutionID int, tagKey string) error {
-	_, err := s.deleteSolutionTagResponseBody(solutionID, tagKey)
+// DeleteSolutionTagV1 removes a solution v1 tag
+func (s *Service) DeleteSolutionTagV1(solutionID int, tagKey string) error {
+	_, err := s.deleteSolutionTagV1ResponseBody(solutionID, tagKey)
 
 	return err
 }
 
-func (s *Service) deleteSolutionTagResponseBody(solutionID int, tagKey string) (*connection.APIResponseBody, error) {
+func (s *Service) deleteSolutionTagV1ResponseBody(solutionID int, tagKey string) (*connection.APIResponseBody, error) {
 	body := &connection.APIResponseBody{}
 
 	if solutionID < 1 {
@@ -586,7 +586,7 @@ func (s *Service) deleteSolutionTagResponseBody(solutionID int, tagKey string) (
 	}
 	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
 		if response.StatusCode == 404 {
-			return &TagNotFoundError{Key: tagKey}
+			return &TagV1NotFoundError{Key: tagKey}
 		}
 
 		return nil

--- a/pkg/service/ecloud/service_solution_test.go
+++ b/pkg/service/ecloud/service_solution_test.go
@@ -1094,7 +1094,7 @@ func TestDeleteSolutionTemplate(t *testing.T) {
 	})
 }
 
-func TestGetSolutionTags(t *testing.T) {
+func TestGetSolutionTagsV1(t *testing.T) {
 	t.Run("Single", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -1112,7 +1112,7 @@ func TestGetSolutionTags(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		tags, err := s.GetSolutionTags(123, connection.APIRequestParameters{})
+		tags, err := s.GetSolutionTagsV1(123, connection.APIRequestParameters{})
 
 		assert.Nil(t, err)
 		assert.Len(t, tags, 1)
@@ -1144,7 +1144,7 @@ func TestGetSolutionTags(t *testing.T) {
 			}, nil),
 		)
 
-		tags, err := s.GetSolutionTags(123, connection.APIRequestParameters{})
+		tags, err := s.GetSolutionTagsV1(123, connection.APIRequestParameters{})
 
 		assert.Nil(t, err)
 		assert.Len(t, tags, 2)
@@ -1164,14 +1164,14 @@ func TestGetSolutionTags(t *testing.T) {
 
 		c.EXPECT().Get("/ecloud/v1/solutions/123/tags", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1"))
 
-		_, err := s.GetSolutionTags(123, connection.APIRequestParameters{})
+		_, err := s.GetSolutionTagsV1(123, connection.APIRequestParameters{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
 	})
 }
 
-func TestGetSolutionTag(t *testing.T) {
+func TestGetSolutionTagV1(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -1189,7 +1189,7 @@ func TestGetSolutionTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		solution, err := s.GetSolutionTag(123, "testkey1")
+		solution, err := s.GetSolutionTagV1(123, "testkey1")
 
 		assert.Nil(t, err)
 		assert.Equal(t, "testkey1", solution.Key)
@@ -1207,7 +1207,7 @@ func TestGetSolutionTag(t *testing.T) {
 
 		c.EXPECT().Get("/ecloud/v1/solutions/123/tags/testkey1", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		_, err := s.GetSolutionTag(123, "testkey1")
+		_, err := s.GetSolutionTagV1(123, "testkey1")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -1223,7 +1223,7 @@ func TestGetSolutionTag(t *testing.T) {
 			connection: c,
 		}
 
-		_, err := s.GetSolutionTag(0, "testkey1")
+		_, err := s.GetSolutionTagV1(0, "testkey1")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid solution id", err.Error())
@@ -1239,7 +1239,7 @@ func TestGetSolutionTag(t *testing.T) {
 			connection: c,
 		}
 
-		_, err := s.GetSolutionTag(123, "")
+		_, err := s.GetSolutionTagV1(123, "")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid tag key", err.Error())
@@ -1262,14 +1262,14 @@ func TestGetSolutionTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		_, err := s.GetSolutionTag(123, "testkey1")
+		_, err := s.GetSolutionTagV1(123, "testkey1")
 
 		assert.NotNil(t, err)
-		assert.IsType(t, &TagNotFoundError{}, err)
+		assert.IsType(t, &TagV1NotFoundError{}, err)
 	})
 }
 
-func TestCreateSolutionTag(t *testing.T) {
+func TestCreateSolutionTagV1(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -1280,14 +1280,14 @@ func TestCreateSolutionTag(t *testing.T) {
 			connection: c,
 		}
 
-		c.EXPECT().Post("/ecloud/v1/solutions/123/tags", gomock.Eq(&CreateTagRequest{Key: "testkey1", Value: "test value 1"})).Return(&connection.APIResponse{
+		c.EXPECT().Post("/ecloud/v1/solutions/123/tags", gomock.Eq(&CreateTagV1Request{Key: "testkey1", Value: "test value 1"})).Return(&connection.APIResponse{
 			Response: &http.Response{
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 				StatusCode: 201,
 			},
 		}, nil).Times(1)
 
-		err := s.CreateSolutionTag(123, CreateTagRequest{Key: "testkey1", Value: "test value 1"})
+		err := s.CreateSolutionTagV1(123, CreateTagV1Request{Key: "testkey1", Value: "test value 1"})
 
 		assert.Nil(t, err)
 	})
@@ -1304,7 +1304,7 @@ func TestCreateSolutionTag(t *testing.T) {
 
 		c.EXPECT().Post("/ecloud/v1/solutions/123/tags", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		err := s.CreateSolutionTag(123, CreateTagRequest{Key: "testkey1", Value: "test value 1"})
+		err := s.CreateSolutionTagV1(123, CreateTagV1Request{Key: "testkey1", Value: "test value 1"})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -1320,7 +1320,7 @@ func TestCreateSolutionTag(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.CreateSolutionTag(0, CreateTagRequest{Key: "testkey1", Value: "test value 1"})
+		err := s.CreateSolutionTagV1(0, CreateTagV1Request{Key: "testkey1", Value: "test value 1"})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid solution id", err.Error())
@@ -1343,14 +1343,14 @@ func TestCreateSolutionTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.CreateSolutionTag(123, CreateTagRequest{Key: "testkey1", Value: "test value 1"})
+		err := s.CreateSolutionTagV1(123, CreateTagV1Request{Key: "testkey1", Value: "test value 1"})
 
 		assert.NotNil(t, err)
 		assert.IsType(t, &SolutionNotFoundError{}, err)
 	})
 }
 
-func TestPatchSolutionTag(t *testing.T) {
+func TestPatchSolutionTagV1(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -1361,7 +1361,7 @@ func TestPatchSolutionTag(t *testing.T) {
 			connection: c,
 		}
 
-		patch := PatchTagRequest{
+		patch := PatchTagV1Request{
 			Value: "new test value 1",
 		}
 
@@ -1372,7 +1372,7 @@ func TestPatchSolutionTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.PatchSolutionTag(123, "testkey1", patch)
+		err := s.PatchSolutionTagV1(123, "testkey1", patch)
 
 		assert.Nil(t, err)
 	})
@@ -1389,7 +1389,7 @@ func TestPatchSolutionTag(t *testing.T) {
 
 		c.EXPECT().Patch("/ecloud/v1/solutions/123/tags/testkey1", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		err := s.PatchSolutionTag(123, "testkey1", PatchTagRequest{})
+		err := s.PatchSolutionTagV1(123, "testkey1", PatchTagV1Request{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -1405,7 +1405,7 @@ func TestPatchSolutionTag(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.PatchSolutionTag(0, "testkey1", PatchTagRequest{})
+		err := s.PatchSolutionTagV1(0, "testkey1", PatchTagV1Request{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid solution id", err.Error())
@@ -1421,7 +1421,7 @@ func TestPatchSolutionTag(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.PatchSolutionTag(123, "", PatchTagRequest{})
+		err := s.PatchSolutionTagV1(123, "", PatchTagV1Request{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid tag key", err.Error())
@@ -1444,14 +1444,14 @@ func TestPatchSolutionTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.PatchSolutionTag(123, "testkey1", PatchTagRequest{})
+		err := s.PatchSolutionTagV1(123, "testkey1", PatchTagV1Request{})
 
 		assert.NotNil(t, err)
-		assert.IsType(t, &TagNotFoundError{}, err)
+		assert.IsType(t, &TagV1NotFoundError{}, err)
 	})
 }
 
-func TestDeleteSolutionTag(t *testing.T) {
+func TestDeleteSolutionTagV1(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -1469,7 +1469,7 @@ func TestDeleteSolutionTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.DeleteSolutionTag(123, "testkey1")
+		err := s.DeleteSolutionTagV1(123, "testkey1")
 
 		assert.Nil(t, err)
 	})
@@ -1486,7 +1486,7 @@ func TestDeleteSolutionTag(t *testing.T) {
 
 		c.EXPECT().Delete("/ecloud/v1/solutions/123/tags/testkey1", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		err := s.DeleteSolutionTag(123, "testkey1")
+		err := s.DeleteSolutionTagV1(123, "testkey1")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -1502,7 +1502,7 @@ func TestDeleteSolutionTag(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.DeleteSolutionTag(0, "testkey1")
+		err := s.DeleteSolutionTagV1(0, "testkey1")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid solution id", err.Error())
@@ -1518,7 +1518,7 @@ func TestDeleteSolutionTag(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.DeleteSolutionTag(123, "")
+		err := s.DeleteSolutionTagV1(123, "")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid tag key", err.Error())
@@ -1541,9 +1541,9 @@ func TestDeleteSolutionTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.DeleteSolutionTag(123, "testkey1")
+		err := s.DeleteSolutionTagV1(123, "testkey1")
 
 		assert.NotNil(t, err)
-		assert.IsType(t, &TagNotFoundError{}, err)
+		assert.IsType(t, &TagV1NotFoundError{}, err)
 	})
 }

--- a/pkg/service/ecloud/service_tags.go
+++ b/pkg/service/ecloud/service_tags.go
@@ -1,0 +1,131 @@
+package ecloud
+
+import (
+	"fmt"
+
+	"github.com/ans-group/sdk-go/pkg/connection"
+)
+
+// GetTagsV2 retrieves a list of tags
+func (s *Service) GetTagsV2(parameters connection.APIRequestParameters) ([]TagV2, error) {
+	return connection.InvokeRequestAll(s.GetTagsV2Paginated, parameters)
+}
+
+// GetTagsV2Paginated retrieves a paginated list of tags
+func (s *Service) GetTagsV2Paginated(parameters connection.APIRequestParameters) (*connection.Paginated[TagV2], error) {
+	body, err := s.getTagsV2PaginatedResponseBody(parameters)
+	return connection.NewPaginated(body, parameters, s.GetTagsV2Paginated), err
+}
+
+func (s *Service) getTagsV2PaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]TagV2], error) {
+	body := &connection.APIResponseBodyData[[]TagV2]{}
+
+	response, err := s.connection.Get("/ecloud/v2/tags", parameters)
+	if err != nil {
+		return body, err
+	}
+
+	return body, response.HandleResponse(body, nil)
+}
+
+// GetTagV2 retrieves a single tag by id
+func (s *Service) GetTagV2(tagID string) (TagV2, error) {
+	body, err := s.getTagV2ResponseBody(tagID)
+
+	return body.Data, err
+}
+
+func (s *Service) getTagV2ResponseBody(tagID string) (*connection.APIResponseBodyData[TagV2], error) {
+	body := &connection.APIResponseBodyData[TagV2]{}
+
+	if tagID == "" {
+		return body, fmt.Errorf("ecloud: invalid tag id")
+	}
+
+	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/tags/%s", tagID), connection.APIRequestParameters{})
+	if err != nil {
+		return body, err
+	}
+
+	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
+		if response.StatusCode == 404 {
+			return &TagV2NotFoundError{ID: tagID}
+		}
+
+		return nil
+	})
+}
+
+// CreateTagV2 creates a new tag
+func (s *Service) CreateTagV2(req CreateTagV2Request) (string, error) {
+	body, err := s.createTagV2ResponseBody(req)
+
+	return body.Data.ID, err
+}
+
+func (s *Service) createTagV2ResponseBody(req CreateTagV2Request) (*connection.APIResponseBodyData[TagV2], error) {
+	body := &connection.APIResponseBodyData[TagV2]{}
+
+	response, err := s.connection.Post("/ecloud/v2/tags", &req)
+	if err != nil {
+		return body, err
+	}
+
+	return body, response.HandleResponse(body, nil)
+}
+
+// PatchTagV2 patches a tag
+func (s *Service) PatchTagV2(tagID string, req PatchTagV2Request) error {
+	_, err := s.patchTagV2ResponseBody(tagID, req)
+
+	return err
+}
+
+func (s *Service) patchTagV2ResponseBody(tagID string, req PatchTagV2Request) (*connection.APIResponseBody, error) {
+	body := &connection.APIResponseBody{}
+
+	if tagID == "" {
+		return body, fmt.Errorf("ecloud: invalid tag id")
+	}
+
+	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/tags/%s", tagID), &req)
+	if err != nil {
+		return body, err
+	}
+
+	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
+		if response.StatusCode == 404 {
+			return &TagV2NotFoundError{ID: tagID}
+		}
+
+		return nil
+	})
+}
+
+// DeleteTagV2 removes a tag
+func (s *Service) DeleteTagV2(tagID string) error {
+	_, err := s.deleteTagV2ResponseBody(tagID)
+
+	return err
+}
+
+func (s *Service) deleteTagV2ResponseBody(tagID string) (*connection.APIResponseBody, error) {
+	body := &connection.APIResponseBody{}
+
+	if tagID == "" {
+		return body, fmt.Errorf("ecloud: invalid tag id")
+	}
+
+	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/tags/%s", tagID), nil)
+	if err != nil {
+		return body, err
+	}
+
+	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
+		if response.StatusCode == 404 {
+			return &TagV2NotFoundError{ID: tagID}
+		}
+
+		return nil
+	})
+}

--- a/pkg/service/ecloud/service_tags.go
+++ b/pkg/service/ecloud/service_tags.go
@@ -6,19 +6,19 @@ import (
 	"github.com/ans-group/sdk-go/pkg/connection"
 )
 
-// GetTagsV2 retrieves a list of tags
-func (s *Service) GetTagsV2(parameters connection.APIRequestParameters) ([]TagV2, error) {
-	return connection.InvokeRequestAll(s.GetTagsV2Paginated, parameters)
+// GetTags retrieves a list of tags
+func (s *Service) GetTags(parameters connection.APIRequestParameters) ([]Tag, error) {
+	return connection.InvokeRequestAll(s.GetTagsPaginated, parameters)
 }
 
-// GetTagsV2Paginated retrieves a paginated list of tags
-func (s *Service) GetTagsV2Paginated(parameters connection.APIRequestParameters) (*connection.Paginated[TagV2], error) {
-	body, err := s.getTagsV2PaginatedResponseBody(parameters)
-	return connection.NewPaginated(body, parameters, s.GetTagsV2Paginated), err
+// GetTagsPaginated retrieves a paginated list of tags
+func (s *Service) GetTagsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Tag], error) {
+	body, err := s.getTagsPaginatedResponseBody(parameters)
+	return connection.NewPaginated(body, parameters, s.GetTagsPaginated), err
 }
 
-func (s *Service) getTagsV2PaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]TagV2], error) {
-	body := &connection.APIResponseBodyData[[]TagV2]{}
+func (s *Service) getTagsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Tag], error) {
+	body := &connection.APIResponseBodyData[[]Tag]{}
 
 	response, err := s.connection.Get("/ecloud/v2/tags", parameters)
 	if err != nil {
@@ -28,15 +28,15 @@ func (s *Service) getTagsV2PaginatedResponseBody(parameters connection.APIReques
 	return body, response.HandleResponse(body, nil)
 }
 
-// GetTagV2 retrieves a single tag by id
-func (s *Service) GetTagV2(tagID string) (TagV2, error) {
-	body, err := s.getTagV2ResponseBody(tagID)
+// GetTag retrieves a single tag by id
+func (s *Service) GetTag(tagID string) (Tag, error) {
+	body, err := s.getTagResponseBody(tagID)
 
 	return body.Data, err
 }
 
-func (s *Service) getTagV2ResponseBody(tagID string) (*connection.APIResponseBodyData[TagV2], error) {
-	body := &connection.APIResponseBodyData[TagV2]{}
+func (s *Service) getTagResponseBody(tagID string) (*connection.APIResponseBodyData[Tag], error) {
+	body := &connection.APIResponseBodyData[Tag]{}
 
 	if tagID == "" {
 		return body, fmt.Errorf("ecloud: invalid tag id")
@@ -49,22 +49,22 @@ func (s *Service) getTagV2ResponseBody(tagID string) (*connection.APIResponseBod
 
 	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
 		if response.StatusCode == 404 {
-			return &TagV2NotFoundError{ID: tagID}
+			return &TagNotFoundError{ID: tagID}
 		}
 
 		return nil
 	})
 }
 
-// CreateTagV2 creates a new tag
-func (s *Service) CreateTagV2(req CreateTagV2Request) (string, error) {
-	body, err := s.createTagV2ResponseBody(req)
+// CreateTag creates a new tag
+func (s *Service) CreateTag(req CreateTagRequest) (string, error) {
+	body, err := s.createTagResponseBody(req)
 
 	return body.Data.ID, err
 }
 
-func (s *Service) createTagV2ResponseBody(req CreateTagV2Request) (*connection.APIResponseBodyData[TagV2], error) {
-	body := &connection.APIResponseBodyData[TagV2]{}
+func (s *Service) createTagResponseBody(req CreateTagRequest) (*connection.APIResponseBodyData[Tag], error) {
+	body := &connection.APIResponseBodyData[Tag]{}
 
 	response, err := s.connection.Post("/ecloud/v2/tags", &req)
 	if err != nil {
@@ -74,14 +74,14 @@ func (s *Service) createTagV2ResponseBody(req CreateTagV2Request) (*connection.A
 	return body, response.HandleResponse(body, nil)
 }
 
-// PatchTagV2 patches a tag
-func (s *Service) PatchTagV2(tagID string, req PatchTagV2Request) error {
-	_, err := s.patchTagV2ResponseBody(tagID, req)
+// PatchTag patches a tag
+func (s *Service) PatchTag(tagID string, req PatchTagRequest) error {
+	_, err := s.patchTagResponseBody(tagID, req)
 
 	return err
 }
 
-func (s *Service) patchTagV2ResponseBody(tagID string, req PatchTagV2Request) (*connection.APIResponseBody, error) {
+func (s *Service) patchTagResponseBody(tagID string, req PatchTagRequest) (*connection.APIResponseBody, error) {
 	body := &connection.APIResponseBody{}
 
 	if tagID == "" {
@@ -95,21 +95,21 @@ func (s *Service) patchTagV2ResponseBody(tagID string, req PatchTagV2Request) (*
 
 	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
 		if response.StatusCode == 404 {
-			return &TagV2NotFoundError{ID: tagID}
+			return &TagNotFoundError{ID: tagID}
 		}
 
 		return nil
 	})
 }
 
-// DeleteTagV2 removes a tag
-func (s *Service) DeleteTagV2(tagID string) error {
-	_, err := s.deleteTagV2ResponseBody(tagID)
+// DeleteTag removes a tag
+func (s *Service) DeleteTag(tagID string) error {
+	_, err := s.deleteTagResponseBody(tagID)
 
 	return err
 }
 
-func (s *Service) deleteTagV2ResponseBody(tagID string) (*connection.APIResponseBody, error) {
+func (s *Service) deleteTagResponseBody(tagID string) (*connection.APIResponseBody, error) {
 	body := &connection.APIResponseBody{}
 
 	if tagID == "" {
@@ -123,7 +123,7 @@ func (s *Service) deleteTagV2ResponseBody(tagID string) (*connection.APIResponse
 
 	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
 		if response.StatusCode == 404 {
-			return &TagV2NotFoundError{ID: tagID}
+			return &TagNotFoundError{ID: tagID}
 		}
 
 		return nil

--- a/pkg/service/ecloud/service_tags_test.go
+++ b/pkg/service/ecloud/service_tags_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetTagsV2(t *testing.T) {
+func TestGetTags(t *testing.T) {
 	t.Run("Single", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -31,7 +31,7 @@ func TestGetTagsV2(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		tags, err := s.GetTagsV2(connection.APIRequestParameters{})
+		tags, err := s.GetTags(connection.APIRequestParameters{})
 
 		assert.Nil(t, err)
 		assert.Len(t, tags, 1)
@@ -65,7 +65,7 @@ func TestGetTagsV2(t *testing.T) {
 			}, nil),
 		)
 
-		tags, err := s.GetTagsV2(connection.APIRequestParameters{})
+		tags, err := s.GetTags(connection.APIRequestParameters{})
 
 		assert.Nil(t, err)
 		assert.Len(t, tags, 2)
@@ -85,14 +85,14 @@ func TestGetTagsV2(t *testing.T) {
 
 		c.EXPECT().Get("/ecloud/v2/tags", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1"))
 
-		_, err := s.GetTagsV2(connection.APIRequestParameters{})
+		_, err := s.GetTags(connection.APIRequestParameters{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
 	})
 }
 
-func TestGetTagsV2Paginated(t *testing.T) {
+func TestGetTagsPaginated(t *testing.T) {
 	t.Run("Single", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -110,7 +110,7 @@ func TestGetTagsV2Paginated(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		tags, err := s.GetTagsV2Paginated(connection.APIRequestParameters{})
+		tags, err := s.GetTagsPaginated(connection.APIRequestParameters{})
 
 		assert.Nil(t, err)
 		assert.Len(t, tags.Items(), 1)
@@ -129,14 +129,14 @@ func TestGetTagsV2Paginated(t *testing.T) {
 
 		c.EXPECT().Get("/ecloud/v2/tags", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1"))
 
-		_, err := s.GetTagsV2Paginated(connection.APIRequestParameters{})
+		_, err := s.GetTagsPaginated(connection.APIRequestParameters{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
 	})
 }
 
-func TestGetTagV2(t *testing.T) {
+func TestGetTag(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -154,7 +154,7 @@ func TestGetTagV2(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		tag, err := s.GetTagV2("tag-abcdef12")
+		tag, err := s.GetTag("tag-abcdef12")
 
 		assert.Nil(t, err)
 		assert.Equal(t, "tag-abcdef12", tag.ID)
@@ -174,7 +174,7 @@ func TestGetTagV2(t *testing.T) {
 
 		c.EXPECT().Get("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		_, err := s.GetTagV2("tag-abcdef12")
+		_, err := s.GetTag("tag-abcdef12")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -190,13 +190,13 @@ func TestGetTagV2(t *testing.T) {
 			connection: c,
 		}
 
-		_, err := s.GetTagV2("")
+		_, err := s.GetTag("")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "ecloud: invalid tag id", err.Error())
 	})
 
-	t.Run("404_ReturnsTagV2NotFoundError", func(t *testing.T) {
+	t.Run("404_ReturnsTagNotFoundError", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -213,14 +213,14 @@ func TestGetTagV2(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		_, err := s.GetTagV2("tag-abcdef12")
+		_, err := s.GetTag("tag-abcdef12")
 
 		assert.NotNil(t, err)
-		assert.IsType(t, &TagV2NotFoundError{}, err)
+		assert.IsType(t, &TagNotFoundError{}, err)
 	})
 }
 
-func TestCreateTagV2(t *testing.T) {
+func TestCreateTag(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -231,7 +231,7 @@ func TestCreateTagV2(t *testing.T) {
 			connection: c,
 		}
 
-		req := CreateTagV2Request{
+		req := CreateTagRequest{
 			Name:  "test-tag",
 			Scope: "global",
 		}
@@ -243,7 +243,7 @@ func TestCreateTagV2(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		tagID, err := s.CreateTagV2(req)
+		tagID, err := s.CreateTag(req)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "tag-abcdef12", tagID)
@@ -261,14 +261,14 @@ func TestCreateTagV2(t *testing.T) {
 
 		c.EXPECT().Post("/ecloud/v2/tags", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		_, err := s.CreateTagV2(CreateTagV2Request{})
+		_, err := s.CreateTag(CreateTagRequest{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
 	})
 }
 
-func TestPatchTagV2(t *testing.T) {
+func TestPatchTag(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -279,7 +279,7 @@ func TestPatchTagV2(t *testing.T) {
 			connection: c,
 		}
 
-		req := PatchTagV2Request{
+		req := PatchTagRequest{
 			Name:  "updated-tag",
 			Scope: "vpc",
 		}
@@ -291,7 +291,7 @@ func TestPatchTagV2(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.PatchTagV2("tag-abcdef12", req)
+		err := s.PatchTag("tag-abcdef12", req)
 
 		assert.Nil(t, err)
 	})
@@ -308,7 +308,7 @@ func TestPatchTagV2(t *testing.T) {
 
 		c.EXPECT().Patch("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		err := s.PatchTagV2("tag-abcdef12", PatchTagV2Request{})
+		err := s.PatchTag("tag-abcdef12", PatchTagRequest{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -324,13 +324,13 @@ func TestPatchTagV2(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.PatchTagV2("", PatchTagV2Request{})
+		err := s.PatchTag("", PatchTagRequest{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "ecloud: invalid tag id", err.Error())
 	})
 
-	t.Run("404_ReturnsTagV2NotFoundError", func(t *testing.T) {
+	t.Run("404_ReturnsTagNotFoundError", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -347,14 +347,14 @@ func TestPatchTagV2(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.PatchTagV2("tag-abcdef12", PatchTagV2Request{})
+		err := s.PatchTag("tag-abcdef12", PatchTagRequest{})
 
 		assert.NotNil(t, err)
-		assert.IsType(t, &TagV2NotFoundError{}, err)
+		assert.IsType(t, &TagNotFoundError{}, err)
 	})
 }
 
-func TestDeleteTagV2(t *testing.T) {
+func TestDeleteTag(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -372,7 +372,7 @@ func TestDeleteTagV2(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.DeleteTagV2("tag-abcdef12")
+		err := s.DeleteTag("tag-abcdef12")
 
 		assert.Nil(t, err)
 	})
@@ -389,7 +389,7 @@ func TestDeleteTagV2(t *testing.T) {
 
 		c.EXPECT().Delete("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		err := s.DeleteTagV2("tag-abcdef12")
+		err := s.DeleteTag("tag-abcdef12")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -405,13 +405,13 @@ func TestDeleteTagV2(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.DeleteTagV2("")
+		err := s.DeleteTag("")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "ecloud: invalid tag id", err.Error())
 	})
 
-	t.Run("404_ReturnsTagV2NotFoundError", func(t *testing.T) {
+	t.Run("404_ReturnsTagNotFoundError", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -428,9 +428,9 @@ func TestDeleteTagV2(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.DeleteTagV2("tag-abcdef12")
+		err := s.DeleteTag("tag-abcdef12")
 
 		assert.NotNil(t, err)
-		assert.IsType(t, &TagV2NotFoundError{}, err)
+		assert.IsType(t, &TagNotFoundError{}, err)
 	})
 }

--- a/pkg/service/ecloud/service_tags_test.go
+++ b/pkg/service/ecloud/service_tags_test.go
@@ -1,0 +1,436 @@
+package ecloud
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/test/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTagsV2(t *testing.T) {
+	t.Run("Single", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Get("/ecloud/v2/tags", gomock.Any()).Return(&connection.APIResponse{
+			Response: &http.Response{
+				Body:       io.NopCloser(bytes.NewReader([]byte("{\"data\":[{\"id\":\"tag-abcdef12\",\"name\":\"test-tag\",\"scope\":\"global\"}],\"meta\":{\"pagination\":{\"total_pages\":1}}}"))),
+				StatusCode: 200,
+			},
+		}, nil).Times(1)
+
+		tags, err := s.GetTagsV2(connection.APIRequestParameters{})
+
+		assert.Nil(t, err)
+		assert.Len(t, tags, 1)
+		assert.Equal(t, "tag-abcdef12", tags[0].ID)
+		assert.Equal(t, "test-tag", tags[0].Name)
+		assert.Equal(t, "global", tags[0].Scope)
+	})
+
+	t.Run("Multiple", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		gomock.InOrder(
+			c.EXPECT().Get("/ecloud/v2/tags", gomock.Any()).Return(&connection.APIResponse{
+				Response: &http.Response{
+					Body:       io.NopCloser(bytes.NewReader([]byte("{\"data\":[{\"id\":\"tag-abcdef12\"}],\"meta\":{\"pagination\":{\"total_pages\":2}}}"))),
+					StatusCode: 200,
+				},
+			}, nil),
+			c.EXPECT().Get("/ecloud/v2/tags", gomock.Any()).Return(&connection.APIResponse{
+				Response: &http.Response{
+					Body:       io.NopCloser(bytes.NewReader([]byte("{\"data\":[{\"id\":\"tag-abcdef23\"}],\"meta\":{\"pagination\":{\"total_pages\":2}}}"))),
+					StatusCode: 200,
+				},
+			}, nil),
+		)
+
+		tags, err := s.GetTagsV2(connection.APIRequestParameters{})
+
+		assert.Nil(t, err)
+		assert.Len(t, tags, 2)
+		assert.Equal(t, "tag-abcdef12", tags[0].ID)
+		assert.Equal(t, "tag-abcdef23", tags[1].ID)
+	})
+
+	t.Run("ConnectionError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Get("/ecloud/v2/tags", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1"))
+
+		_, err := s.GetTagsV2(connection.APIRequestParameters{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "test error 1", err.Error())
+	})
+}
+
+func TestGetTagsV2Paginated(t *testing.T) {
+	t.Run("Single", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Get("/ecloud/v2/tags", gomock.Any()).Return(&connection.APIResponse{
+			Response: &http.Response{
+				Body:       io.NopCloser(bytes.NewReader([]byte("{\"data\":[{\"id\":\"tag-abcdef12\"}],\"meta\":{\"pagination\":{\"total_pages\":1}}}"))),
+				StatusCode: 200,
+			},
+		}, nil).Times(1)
+
+		tags, err := s.GetTagsV2Paginated(connection.APIRequestParameters{})
+
+		assert.Nil(t, err)
+		assert.Len(t, tags.Items(), 1)
+		assert.Equal(t, "tag-abcdef12", tags.Items()[0].ID)
+	})
+
+	t.Run("ConnectionError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Get("/ecloud/v2/tags", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1"))
+
+		_, err := s.GetTagsV2Paginated(connection.APIRequestParameters{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "test error 1", err.Error())
+	})
+}
+
+func TestGetTagV2(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Get("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{
+			Response: &http.Response{
+				Body:       io.NopCloser(bytes.NewReader([]byte("{\"data\":{\"id\":\"tag-abcdef12\",\"name\":\"test-tag\",\"scope\":\"global\"}}"))),
+				StatusCode: 200,
+			},
+		}, nil).Times(1)
+
+		tag, err := s.GetTagV2("tag-abcdef12")
+
+		assert.Nil(t, err)
+		assert.Equal(t, "tag-abcdef12", tag.ID)
+		assert.Equal(t, "test-tag", tag.Name)
+		assert.Equal(t, "global", tag.Scope)
+	})
+
+	t.Run("ConnectionError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Get("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
+
+		_, err := s.GetTagV2("tag-abcdef12")
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "test error 1", err.Error())
+	})
+
+	t.Run("InvalidTagID_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		_, err := s.GetTagV2("")
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "ecloud: invalid tag id", err.Error())
+	})
+
+	t.Run("404_ReturnsTagV2NotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Get("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{
+			Response: &http.Response{
+				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+				StatusCode: 404,
+			},
+		}, nil).Times(1)
+
+		_, err := s.GetTagV2("tag-abcdef12")
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &TagV2NotFoundError{}, err)
+	})
+}
+
+func TestCreateTagV2(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		req := CreateTagV2Request{
+			Name:  "test-tag",
+			Scope: "global",
+		}
+
+		c.EXPECT().Post("/ecloud/v2/tags", &req).Return(&connection.APIResponse{
+			Response: &http.Response{
+				Body:       io.NopCloser(bytes.NewReader([]byte("{\"data\":{\"id\":\"tag-abcdef12\"}}"))),
+				StatusCode: 201,
+			},
+		}, nil).Times(1)
+
+		tagID, err := s.CreateTagV2(req)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "tag-abcdef12", tagID)
+	})
+
+	t.Run("ConnectionError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Post("/ecloud/v2/tags", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
+
+		_, err := s.CreateTagV2(CreateTagV2Request{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "test error 1", err.Error())
+	})
+}
+
+func TestPatchTagV2(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		req := PatchTagV2Request{
+			Name:  "updated-tag",
+			Scope: "vpc",
+		}
+
+		c.EXPECT().Patch("/ecloud/v2/tags/tag-abcdef12", &req).Return(&connection.APIResponse{
+			Response: &http.Response{
+				Body:       io.NopCloser(bytes.NewReader([]byte("{}"))),
+				StatusCode: 200,
+			},
+		}, nil).Times(1)
+
+		err := s.PatchTagV2("tag-abcdef12", req)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("ConnectionError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Patch("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
+
+		err := s.PatchTagV2("tag-abcdef12", PatchTagV2Request{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "test error 1", err.Error())
+	})
+
+	t.Run("InvalidTagID_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		err := s.PatchTagV2("", PatchTagV2Request{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "ecloud: invalid tag id", err.Error())
+	})
+
+	t.Run("404_ReturnsTagV2NotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Patch("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{
+			Response: &http.Response{
+				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+				StatusCode: 404,
+			},
+		}, nil).Times(1)
+
+		err := s.PatchTagV2("tag-abcdef12", PatchTagV2Request{})
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &TagV2NotFoundError{}, err)
+	})
+}
+
+func TestDeleteTagV2(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Delete("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{
+			Response: &http.Response{
+				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+				StatusCode: 204,
+			},
+		}, nil).Times(1)
+
+		err := s.DeleteTagV2("tag-abcdef12")
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("ConnectionError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Delete("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
+
+		err := s.DeleteTagV2("tag-abcdef12")
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "test error 1", err.Error())
+	})
+
+	t.Run("InvalidTagID_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		err := s.DeleteTagV2("")
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "ecloud: invalid tag id", err.Error())
+	})
+
+	t.Run("404_ReturnsTagV2NotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		c := mocks.NewMockConnection(mockCtrl)
+
+		s := Service{
+			connection: c,
+		}
+
+		c.EXPECT().Delete("/ecloud/v2/tags/tag-abcdef12", gomock.Any()).Return(&connection.APIResponse{
+			Response: &http.Response{
+				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+				StatusCode: 404,
+			},
+		}, nil).Times(1)
+
+		err := s.DeleteTagV2("tag-abcdef12")
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &TagV2NotFoundError{}, err)
+	})
+}

--- a/pkg/service/ecloud/service_virtualmachine.go
+++ b/pkg/service/ecloud/service_virtualmachine.go
@@ -327,23 +327,23 @@ func (s *Service) createVirtualMachineTemplateResponseBody(vmID int, req CreateV
 }
 
 // GetVirtualMachineTags retrieves a list of tags
-func (s *Service) GetVirtualMachineTags(vmID int, parameters connection.APIRequestParameters) ([]Tag, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Tag], error) {
-		return s.GetVirtualMachineTagsPaginated(vmID, p)
+func (s *Service) GetVirtualMachineTagsV1(vmID int, parameters connection.APIRequestParameters) ([]TagV1, error) {
+	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[TagV1], error) {
+		return s.GetVirtualMachineTagsV1Paginated(vmID, p)
 	}, parameters)
 }
 
-// GetVirtualMachineTagsPaginated retrieves a paginated list of domains
-func (s *Service) GetVirtualMachineTagsPaginated(vmID int, parameters connection.APIRequestParameters) (*connection.Paginated[Tag], error) {
-	body, err := s.getVirtualMachineTagsPaginatedResponseBody(vmID, parameters)
+// GetVirtualMachineTagsV1Paginated retrieves a paginated list of v1 virtual machine tags
+func (s *Service) GetVirtualMachineTagsV1Paginated(vmID int, parameters connection.APIRequestParameters) (*connection.Paginated[TagV1], error) {
+	body, err := s.getVirtualMachineTagsV1PaginatedResponseBody(vmID, parameters)
 
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Tag], error) {
-		return s.GetVirtualMachineTagsPaginated(vmID, p)
+	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[TagV1], error) {
+		return s.GetVirtualMachineTagsV1Paginated(vmID, p)
 	}), err
 }
 
-func (s *Service) getVirtualMachineTagsPaginatedResponseBody(vmID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Tag], error) {
-	body := &connection.APIResponseBodyData[[]Tag]{}
+func (s *Service) getVirtualMachineTagsV1PaginatedResponseBody(vmID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]TagV1], error) {
+	body := &connection.APIResponseBodyData[[]TagV1]{}
 
 	if vmID < 1 {
 		return body, fmt.Errorf("invalid virtual machine id")
@@ -363,15 +363,15 @@ func (s *Service) getVirtualMachineTagsPaginatedResponseBody(vmID int, parameter
 	})
 }
 
-// GetVirtualMachineTag retrieves a single virtual machine tag by key
-func (s *Service) GetVirtualMachineTag(vmID int, tagKey string) (Tag, error) {
-	body, err := s.getVirtualMachineTagResponseBody(vmID, tagKey)
+// GetVirtualMachineTagV1 retrieves a single virtual machine v1 tag by key
+func (s *Service) GetVirtualMachineTagV1(vmID int, tagKey string) (TagV1, error) {
+	body, err := s.getVirtualMachineTagV1ResponseBody(vmID, tagKey)
 
 	return body.Data, err
 }
 
-func (s *Service) getVirtualMachineTagResponseBody(vmID int, tagKey string) (*connection.APIResponseBodyData[Tag], error) {
-	body := &connection.APIResponseBodyData[Tag]{}
+func (s *Service) getVirtualMachineTagV1ResponseBody(vmID int, tagKey string) (*connection.APIResponseBodyData[TagV1], error) {
+	body := &connection.APIResponseBodyData[TagV1]{}
 
 	if vmID < 1 {
 		return body, fmt.Errorf("invalid virtual machine id")
@@ -387,21 +387,21 @@ func (s *Service) getVirtualMachineTagResponseBody(vmID int, tagKey string) (*co
 
 	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
 		if response.StatusCode == 404 {
-			return &TagNotFoundError{Key: tagKey}
+			return &TagV1NotFoundError{Key: tagKey}
 		}
 
 		return nil
 	})
 }
 
-// CreateVirtualMachineTag creates a new virtual machine tag
-func (s *Service) CreateVirtualMachineTag(vmID int, req CreateTagRequest) error {
-	_, err := s.createVirtualMachineTagResponseBody(vmID, req)
+// CreateVirtualMachineTagV1 creates a new virtual machine v1 tag
+func (s *Service) CreateVirtualMachineTagV1(vmID int, req CreateTagV1Request) error {
+	_, err := s.createVirtualMachineTagV1ResponseBody(vmID, req)
 
 	return err
 }
 
-func (s *Service) createVirtualMachineTagResponseBody(vmID int, req CreateTagRequest) (*connection.APIResponseBody, error) {
+func (s *Service) createVirtualMachineTagV1ResponseBody(vmID int, req CreateTagV1Request) (*connection.APIResponseBody, error) {
 	body := &connection.APIResponseBody{}
 
 	if vmID < 1 {
@@ -422,14 +422,14 @@ func (s *Service) createVirtualMachineTagResponseBody(vmID int, req CreateTagReq
 	})
 }
 
-// PatchVirtualMachineTag patches an eCloud virtual machine tag
-func (s *Service) PatchVirtualMachineTag(vmID int, tagKey string, patch PatchTagRequest) error {
-	_, err := s.patchVirtualMachineTagResponseBody(vmID, tagKey, patch)
+// PatchVirtualMachineTagV1 patches an eCloud virtual machine v1 tag
+func (s *Service) PatchVirtualMachineTagV1(vmID int, tagKey string, patch PatchTagV1Request) error {
+	_, err := s.patchVirtualMachineTagV1ResponseBody(vmID, tagKey, patch)
 
 	return err
 }
 
-func (s *Service) patchVirtualMachineTagResponseBody(vmID int, tagKey string, patch PatchTagRequest) (*connection.APIResponseBody, error) {
+func (s *Service) patchVirtualMachineTagV1ResponseBody(vmID int, tagKey string, patch PatchTagV1Request) (*connection.APIResponseBody, error) {
 	body := &connection.APIResponseBody{}
 
 	if vmID < 1 {
@@ -446,21 +446,21 @@ func (s *Service) patchVirtualMachineTagResponseBody(vmID int, tagKey string, pa
 
 	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
 		if response.StatusCode == 404 {
-			return &TagNotFoundError{Key: tagKey}
+			return &TagV1NotFoundError{Key: tagKey}
 		}
 
 		return nil
 	})
 }
 
-// DeleteVirtualMachineTag removes a virtual machine tag
-func (s *Service) DeleteVirtualMachineTag(vmID int, tagKey string) error {
-	_, err := s.deleteVirtualMachineTagResponseBody(vmID, tagKey)
+// DeleteVirtualMachineTagV1 removes a virtual machine v1 tag
+func (s *Service) DeleteVirtualMachineTagV1(vmID int, tagKey string) error {
+	_, err := s.deleteVirtualMachineTagV1ResponseBody(vmID, tagKey)
 
 	return err
 }
 
-func (s *Service) deleteVirtualMachineTagResponseBody(vmID int, tagKey string) (*connection.APIResponseBody, error) {
+func (s *Service) deleteVirtualMachineTagV1ResponseBody(vmID int, tagKey string) (*connection.APIResponseBody, error) {
 	body := &connection.APIResponseBody{}
 
 	if vmID < 1 {
@@ -477,7 +477,7 @@ func (s *Service) deleteVirtualMachineTagResponseBody(vmID int, tagKey string) (
 
 	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
 		if response.StatusCode == 404 {
-			return &TagNotFoundError{Key: tagKey}
+			return &TagV1NotFoundError{Key: tagKey}
 		}
 
 		return nil

--- a/pkg/service/ecloud/service_virtualmachine_test.go
+++ b/pkg/service/ecloud/service_virtualmachine_test.go
@@ -964,7 +964,7 @@ func TestCreateVirtualMachineTemplate(t *testing.T) {
 	})
 }
 
-func TestGetVirtualMachineTags(t *testing.T) {
+func TestGetVirtualMachineTagsV1(t *testing.T) {
 	t.Run("Single", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -982,7 +982,7 @@ func TestGetVirtualMachineTags(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		tags, err := s.GetVirtualMachineTags(123, connection.APIRequestParameters{})
+		tags, err := s.GetVirtualMachineTagsV1(123, connection.APIRequestParameters{})
 
 		assert.Nil(t, err)
 		assert.Len(t, tags, 1)
@@ -1014,7 +1014,7 @@ func TestGetVirtualMachineTags(t *testing.T) {
 			}, nil),
 		)
 
-		tags, err := s.GetVirtualMachineTags(123, connection.APIRequestParameters{})
+		tags, err := s.GetVirtualMachineTagsV1(123, connection.APIRequestParameters{})
 
 		assert.Nil(t, err)
 		assert.Len(t, tags, 2)
@@ -1034,14 +1034,14 @@ func TestGetVirtualMachineTags(t *testing.T) {
 
 		c.EXPECT().Get("/ecloud/v1/vms/123/tags", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1"))
 
-		_, err := s.GetVirtualMachineTags(123, connection.APIRequestParameters{})
+		_, err := s.GetVirtualMachineTagsV1(123, connection.APIRequestParameters{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
 	})
 }
 
-func TestGetVirtualMachineTag(t *testing.T) {
+func TestGetVirtualMachineTagV1(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -1059,7 +1059,7 @@ func TestGetVirtualMachineTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		vm, err := s.GetVirtualMachineTag(123, "testkey1")
+		vm, err := s.GetVirtualMachineTagV1(123, "testkey1")
 
 		assert.Nil(t, err)
 		assert.Equal(t, "testkey1", vm.Key)
@@ -1077,7 +1077,7 @@ func TestGetVirtualMachineTag(t *testing.T) {
 
 		c.EXPECT().Get("/ecloud/v1/vms/123/tags/testkey1", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		_, err := s.GetVirtualMachineTag(123, "testkey1")
+		_, err := s.GetVirtualMachineTagV1(123, "testkey1")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -1093,7 +1093,7 @@ func TestGetVirtualMachineTag(t *testing.T) {
 			connection: c,
 		}
 
-		_, err := s.GetVirtualMachineTag(0, "testkey1")
+		_, err := s.GetVirtualMachineTagV1(0, "testkey1")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid virtual machine id", err.Error())
@@ -1109,7 +1109,7 @@ func TestGetVirtualMachineTag(t *testing.T) {
 			connection: c,
 		}
 
-		_, err := s.GetVirtualMachineTag(123, "")
+		_, err := s.GetVirtualMachineTagV1(123, "")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid tag key", err.Error())
@@ -1132,14 +1132,14 @@ func TestGetVirtualMachineTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		_, err := s.GetVirtualMachineTag(123, "testkey1")
+		_, err := s.GetVirtualMachineTagV1(123, "testkey1")
 
 		assert.NotNil(t, err)
-		assert.IsType(t, &TagNotFoundError{}, err)
+		assert.IsType(t, &TagV1NotFoundError{}, err)
 	})
 }
 
-func TestCreateVirtualMachineTag(t *testing.T) {
+func TestCreateVirtualMachineTagV1(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -1150,14 +1150,14 @@ func TestCreateVirtualMachineTag(t *testing.T) {
 			connection: c,
 		}
 
-		c.EXPECT().Post("/ecloud/v1/vms/123/tags", gomock.Eq(&CreateTagRequest{Key: "testkey1", Value: "test value 1"})).Return(&connection.APIResponse{
+		c.EXPECT().Post("/ecloud/v1/vms/123/tags", gomock.Eq(&CreateTagV1Request{Key: "testkey1", Value: "test value 1"})).Return(&connection.APIResponse{
 			Response: &http.Response{
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 				StatusCode: 201,
 			},
 		}, nil).Times(1)
 
-		err := s.CreateVirtualMachineTag(123, CreateTagRequest{Key: "testkey1", Value: "test value 1"})
+		err := s.CreateVirtualMachineTagV1(123, CreateTagV1Request{Key: "testkey1", Value: "test value 1"})
 
 		assert.Nil(t, err)
 	})
@@ -1174,7 +1174,7 @@ func TestCreateVirtualMachineTag(t *testing.T) {
 
 		c.EXPECT().Post("/ecloud/v1/vms/123/tags", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		err := s.CreateVirtualMachineTag(123, CreateTagRequest{Key: "testkey1", Value: "test value 1"})
+		err := s.CreateVirtualMachineTagV1(123, CreateTagV1Request{Key: "testkey1", Value: "test value 1"})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -1190,7 +1190,7 @@ func TestCreateVirtualMachineTag(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.CreateVirtualMachineTag(0, CreateTagRequest{Key: "testkey1", Value: "test value 1"})
+		err := s.CreateVirtualMachineTagV1(0, CreateTagV1Request{Key: "testkey1", Value: "test value 1"})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid virtual machine id", err.Error())
@@ -1213,14 +1213,14 @@ func TestCreateVirtualMachineTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.CreateVirtualMachineTag(123, CreateTagRequest{Key: "testkey1", Value: "test value 1"})
+		err := s.CreateVirtualMachineTagV1(123, CreateTagV1Request{Key: "testkey1", Value: "test value 1"})
 
 		assert.NotNil(t, err)
 		assert.IsType(t, &VirtualMachineNotFoundError{}, err)
 	})
 }
 
-func TestPatchVirtualMachineTag(t *testing.T) {
+func TestPatchVirtualMachineTagV1(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -1231,7 +1231,7 @@ func TestPatchVirtualMachineTag(t *testing.T) {
 			connection: c,
 		}
 
-		patch := PatchTagRequest{
+		patch := PatchTagV1Request{
 			Value: "new test value 1",
 		}
 
@@ -1242,7 +1242,7 @@ func TestPatchVirtualMachineTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.PatchVirtualMachineTag(123, "testkey1", patch)
+		err := s.PatchVirtualMachineTagV1(123, "testkey1", patch)
 
 		assert.Nil(t, err)
 	})
@@ -1259,7 +1259,7 @@ func TestPatchVirtualMachineTag(t *testing.T) {
 
 		c.EXPECT().Patch("/ecloud/v1/vms/123/tags/testkey1", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		err := s.PatchVirtualMachineTag(123, "testkey1", PatchTagRequest{})
+		err := s.PatchVirtualMachineTagV1(123, "testkey1", PatchTagV1Request{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -1275,7 +1275,7 @@ func TestPatchVirtualMachineTag(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.PatchVirtualMachineTag(0, "testkey1", PatchTagRequest{})
+		err := s.PatchVirtualMachineTagV1(0, "testkey1", PatchTagV1Request{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid virtual machine id", err.Error())
@@ -1291,7 +1291,7 @@ func TestPatchVirtualMachineTag(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.PatchVirtualMachineTag(123, "", PatchTagRequest{})
+		err := s.PatchVirtualMachineTagV1(123, "", PatchTagV1Request{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid tag key", err.Error())
@@ -1314,14 +1314,14 @@ func TestPatchVirtualMachineTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.PatchVirtualMachineTag(123, "testkey1", PatchTagRequest{})
+		err := s.PatchVirtualMachineTagV1(123, "testkey1", PatchTagV1Request{})
 
 		assert.NotNil(t, err)
-		assert.IsType(t, &TagNotFoundError{}, err)
+		assert.IsType(t, &TagV1NotFoundError{}, err)
 	})
 }
 
-func TestDeleteVirtualMachineTag(t *testing.T) {
+func TestDeleteVirtualMachineTagV1(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -1339,7 +1339,7 @@ func TestDeleteVirtualMachineTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.DeleteVirtualMachineTag(123, "testkey1")
+		err := s.DeleteVirtualMachineTagV1(123, "testkey1")
 
 		assert.Nil(t, err)
 	})
@@ -1356,7 +1356,7 @@ func TestDeleteVirtualMachineTag(t *testing.T) {
 
 		c.EXPECT().Delete("/ecloud/v1/vms/123/tags/testkey1", gomock.Any()).Return(&connection.APIResponse{}, errors.New("test error 1")).Times(1)
 
-		err := s.DeleteVirtualMachineTag(123, "testkey1")
+		err := s.DeleteVirtualMachineTagV1(123, "testkey1")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "test error 1", err.Error())
@@ -1372,7 +1372,7 @@ func TestDeleteVirtualMachineTag(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.DeleteVirtualMachineTag(0, "testkey1")
+		err := s.DeleteVirtualMachineTagV1(0, "testkey1")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid virtual machine id", err.Error())
@@ -1388,7 +1388,7 @@ func TestDeleteVirtualMachineTag(t *testing.T) {
 			connection: c,
 		}
 
-		err := s.DeleteVirtualMachineTag(123, "")
+		err := s.DeleteVirtualMachineTagV1(123, "")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "invalid tag key", err.Error())
@@ -1411,10 +1411,10 @@ func TestDeleteVirtualMachineTag(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		err := s.DeleteVirtualMachineTag(123, "testkey1")
+		err := s.DeleteVirtualMachineTagV1(123, "testkey1")
 
 		assert.NotNil(t, err)
-		assert.IsType(t, &TagNotFoundError{}, err)
+		assert.IsType(t, &TagV1NotFoundError{}, err)
 	})
 }
 


### PR DESCRIPTION
**BREAKING**: Renames eCloud V1 tag methods, e.g. `GetSolutionTags` -> `GetSolutionTagsV1`.

Adds CRUD support for the new `ecloud/v2/tags` endpoint and resources.